### PR TITLE
Updated README.md , load script with relative paths, fixed links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ Then to install evaluate:
     
 Ported from:
 
-	http://www.squeaksource.com/Swazoo
-	http://www.squeaksource.com/Swazoo/Swazoo-2.3beta3.1.mcz
+http://www.squeaksource.com/Swazoo
+
+File:
+http://www.squeaksource.com/Swazoo/Swazoo-2.3beta3.1.mcz
 	
 Details on mail with subject: "Porting Sport and Swazoo to Cuis" on AidaWeb list 27/12/2012.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Swazoo for Cuis 4.1
 
 *** This is still work in progress ***
 
+Other repositories needed:
+
+   https://github.com/garduino/Cuis-Cryptography.git
+   https://github.com/garduino/Cuis-Pharo14CompatibilityLayer.git
+   https://github.com/garduino/Cuis-Sport.git
+
+
 To install:
 
     | slash repo |

--- a/README.md
+++ b/README.md
@@ -7,28 +7,27 @@ Swazoo for Cuis 4.1
 
 Other repositories needed:
 
-   https://github.com/garduino/Cuis-Cryptography.git
-   https://github.com/garduino/Cuis-Pharo14CompatibilityLayer.git
-   https://github.com/garduino/Cuis-Sport.git
+*   https://github.com/garduino/Cuis-Cryptography.git  
+*   https://github.com/garduino/Cuis-Pharo14CompatibilityLayer.git
+*   https://github.com/garduino/Cuis-Sport.git
 
+Clone them into sibling directories of your Cuis and Cuis-Swazoo directories 
 
-To install:
+Then to install evaluate:
 
-    | slash repo |
+    | slash  |
     slash _ FileDirectory slash.
-    repo := 'C:\Users\MyUser\Documents\GitHub'. --> *** Replace with your real directory (Windows Sample) ***
-    repo := '/Users/Shared/gsa/Dev/CodeRepository'. --> *** Replace with your real directory (Mac Sample) ***
     {
-    repo, slash, 'Cuis-Cryptography', slash, 'Cuis-System-Hashing.pck.st' .
-    repo, slash, 'Cuis-CompatibilityWithOtherSmalltalks', slash, 'Cuis-CompatibilityWithOtherSmalltalks.pck.st' .
-    repo, slash, 'Cuis-Pharo14CompatibilityLayer', slash, 'Cuis-Network-Protocols.pck.st' .
-    repo, slash, 'Cuis-Pharo14CompatibilityLayer', slash, 'Cuis-Network-Url.pck.st' .
-    repo, slash, 'Cuis-Sport', slash, 'Sport.pck.st' .
-    repo, slash, 'Cuis-Swazoo', slash, 'Swazoo.pck.st' .
+    '..', slash, 'Cuis-Cryptography', slash, 'Cuis-System-Hashing.pck.st' .
+    '..', slash, 'Cuis-CompatibilityWithOtherSmalltalks', slash, 'Cuis-CompatibilityWithOtherSmalltalks.pck.st' .
+    '..', slash, 'Cuis-Pharo14CompatibilityLayer', slash, 'Cuis-Network-Protocols.pck.st' .
+    '..', slash, 'Cuis-Pharo14CompatibilityLayer', slash, 'Cuis-Network-Url.pck.st' .
+    '..', slash, 'Cuis-Sport', slash, 'Sport.pck.st' .
+    '..', slash, 'Cuis-Swazoo', slash, 'Swazoo.pck.st' .
     }
     do:
     [ :fileName | CodePackageFile installPackageStream:
-    (FileStream concreteStream readOnlyFileNamed: fileName)
+        (FileStream concreteStream readOnlyFileNamed: fileName)
     ].
     
 Ported from:
@@ -36,5 +35,6 @@ Ported from:
 	http://www.squeaksource.com/Swazoo
 	http://www.squeaksource.com/Swazoo/Swazoo-2.3beta3.1.mcz
 	
-	Details on mail with subject: "Porting Sport and Swazoo to Cuis" on 
-	AidaWeb list 27/12/2012.
+Details on mail with subject: "Porting Sport and Swazoo to Cuis" on AidaWeb list 27/12/2012.
+
+     http://lists.aidaweb.si/pipermail/aida/2012-December/003347.html

--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ Ported from:
 	
 Details on mail with subject: "Porting Sport and Swazoo to Cuis" on AidaWeb list 27/12/2012.
 
-     http://lists.aidaweb.si/pipermail/aida/2012-December/003347.html
+http://lists.aidaweb.si/pipermail/aida/2012-December/003347.html


### PR DESCRIPTION
A load script with relative paths can be used as is. No need to adapt it. This works if we keep Cuis and all repository directories on the same level.

See 
http://jvuletich.org/pipermail/cuis_jvuletich.org/2013-January/000515.html
